### PR TITLE
使い終わったファイルを削除する

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,6 +24,7 @@ bash "build_and_install_mecab" do
     tar -zxf mecab-#{version}.tar.gz
     (cd mecab-#{version} && ./configure #{node["mecab"]["configure_options"]})
     (cd mecab-#{version} && make && make check && make install)
+    rm -rf mecab-#{version}
   EOH
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,4 +27,8 @@ bash "build_and_install_mecab" do
   EOH
 end
 
+file "#{Chef::Config[:file_cache_path]}/mecab-#{version}.tar.gz" do
+  action :delete
+end
+
 include_recipe "mecab::ipadic"

--- a/recipes/ipadic.rb
+++ b/recipes/ipadic.rb
@@ -23,6 +23,7 @@ bash "build_and_install_ipadic" do
     (cd mecab-ipadic-#{version} && ./configure #{node["ipadic"]["configure_options"]})
     (cd mecab-ipadic-#{version} && /usr/local/libexec/mecab/mecab-dict-index -f euc-jp -t utf-8)
     (cd mecab-ipadic-#{version} && make install)
+    rm -rf mecab-ipadic-#{version}
   EOH
   not_if { ::File.exists?("/usr/local/lib/mecab/dic/ipadic") }
 end

--- a/recipes/ipadic.rb
+++ b/recipes/ipadic.rb
@@ -26,3 +26,7 @@ bash "build_and_install_ipadic" do
   EOH
   not_if { ::File.exists?("/usr/local/lib/mecab/dic/ipadic") }
 end
+
+file "#{Chef::Config[:file_cache_path]}/mecab-ipadic-#{version}.tar.gz" do
+  action :delete
+end


### PR DESCRIPTION
ダウンロードしてきた tar.gz や、展開後のディレクトリは
ビルドが終わった後は不要になると思うので、削除するようにしました。
