### PR TITLE
Fix download url

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,9 @@
 default["mecab"]["version"] = "0.996"
+default["mecab"]["download_id"] = "0B4y35FiV1wh7cENtOXlicTFaRUE"
 default["mecab"]["checksum"] = "15baca0983a61c1a49cffd4a919463a0a39ef127"
 default["mecab"]["configure_options"] = "--with-charset=utf8  --enable-utf8-only"
 
 default["ipadic"]["version"] = "2.7.0-20070801"
+default["ipadic"]["download_id"] = "0B4y35FiV1wh7MWVlSDBCSXZMTXM"
 default["ipadic"]["checksum"] = "0d9d021853ba4bb4adfa782ea450e55bfe1a229b"
 default["ipadic"]["configure_options"] = "--with-charset=utf8 --enable-utf8-only"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,9 +1,9 @@
 default["mecab"]["version"] = "0.996"
 default["mecab"]["download_id"] = "0B4y35FiV1wh7cENtOXlicTFaRUE"
-default["mecab"]["checksum"] = "15baca0983a61c1a49cffd4a919463a0a39ef127"
+default["mecab"]["checksum"] = "e073325783135b72e666145c781bb48fada583d5224fb2490fb6c1403ba69c59"
 default["mecab"]["configure_options"] = "--with-charset=utf8  --enable-utf8-only"
 
 default["ipadic"]["version"] = "2.7.0-20070801"
 default["ipadic"]["download_id"] = "0B4y35FiV1wh7MWVlSDBCSXZMTXM"
-default["ipadic"]["checksum"] = "0d9d021853ba4bb4adfa782ea450e55bfe1a229b"
+default["ipadic"]["checksum"] = "b62f527d881c504576baed9c6ef6561554658b175ce6ae0096a60307e49e3523"
 default["ipadic"]["configure_options"] = "--with-charset=utf8 --enable-utf8-only"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,7 +11,7 @@ version = node["mecab"]["version"]
 
 remote_file "#{Chef::Config[:file_cache_path]}/mecab-#{version}.tar.gz" do
   not_if "which mecab"
-  source "http://mecab.googlecode.com/files/mecab-#{version}.tar.gz"
+  source "https://drive.google.com/uc?id=#{node["mecab"]["download_id"]}"
   checksum node['mecab']['checksum']
   mode "0644"
 end

--- a/recipes/ipadic.rb
+++ b/recipes/ipadic.rb
@@ -9,7 +9,7 @@
 
 version = node["ipadic"]["version"]
 remote_file "#{Chef::Config[:file_cache_path]}/mecab-ipadic-#{version}.tar.gz" do
-  source "https://mecab.googlecode.com/files/mecab-ipadic-#{version}.tar.gz"
+  source "https://drive.google.com/uc?id=#{node["ipadic"]["download_id"]}"
   checksum node['ipadic']['checksum']
   mode "0644"
   not_if { ::File.exists?("/usr/local/lib/mecab/dic/ipadic") }


### PR DESCRIPTION
配信元が google drive に変更されたので url を修正しました。
また、最近の chef のバージョンでは checksum が sha256 になっているので修正しております。

See: https://docs.chef.io/resource_remote_file.html

> Optional, see use_conditional_get. The SHA-256 checksum of the file. Use to prevent a file from being re-downloaded. When the local file matches the checksum, the chef-client does not download it.
